### PR TITLE
Add Limit as parameter to GetRecords

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ KinesisStream.prototype.drainBuffer = function() {
     if (self.shards.every(function(shard) { return shard.ended }))
       return self.push(null)
 
-    self.drainBuffer()
+    if (self.options.backoffTime) {
+      setTimeout(self.drainBuffer.bind(self), self.options.backoffTime)
+    } else {
+      self.drainBuffer()
+    }
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ KinesisStream.prototype.getShardIteratorRecords = function(shard, cb) {
 
 KinesisStream.prototype.getRecords = function(shard, shardIterator, cb) {
   var self = this,
-      data = {StreamName: self.name, ShardId: shard.id, ShardIterator: shardIterator}
+      limit = self.options.limit || 25,
+      data = {ShardIterator: shardIterator, Limit: limit}
 
   request('GetRecords', data, self.options, function(err, res) {
     if (err) return cb(err)


### PR DESCRIPTION
The default limit is set to 25, which is the Kinesis API default. The limit can
be overridden with `options.limit = newLimit`.
