### PR TITLE
Log body length and Content-Length

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,9 @@ function request(action, data, options, cb) {
               host: httpOptions.host,
               path: httpOptions.path,
               action: action,
-              status: res.statusCode
+              status: res.statusCode,
+              length: json.length,
+              content_length: res.headers['content-length']
             });
 
             return cb(null, response)

--- a/index.js
+++ b/index.js
@@ -387,7 +387,8 @@ function request(action, data, options, cb) {
               at: 'finish',
               host: httpOptions.host,
               path: httpOptions.path,
-              action: action
+              action: action,
+              status: res.statusCode
             });
 
             return cb(null, response)


### PR DESCRIPTION
In some scenarios, it seems that Kinesis is returning a 200 while leaving the response body empty.
