### PR TITLE
Socket timeouts require callback to abort connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,7 +421,18 @@ function request(action, data, options, cb) {
         })
       }).on('error', cb)
 
-      if (options.timeout != null) req.setTimeout(options.timeout)
+      if (options.timeout != null) {
+        req.setTimeout(options.timeout, function() {
+          options.logger.log({
+            kinesis_request: true,
+            at: 'timeout',
+            host: httpOptions.host,
+            path: httpOptions.path,
+            action: action,
+          })
+          req.abort()
+        })
+      }
 
       req.end(body)
 


### PR DESCRIPTION
Timeouts without a callback will only raise the `timeout` event, but not abort the connection. This was detected due to a few incidents where connections were not timing out as expected.
