### PR TITLE
fix Cannot read property 'log' of undefinedof logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -510,6 +510,7 @@ function resolveOptions(options) {
     options.host = region
   }
   if (!options.version) options.version = '20131202'
+  if (!options.logger) options.logger = nullLogger
 
   return options
 }


### PR DESCRIPTION
Without that all the exemple are failing:

```
/Users/adrienbecchis/git/kinesis/index.js:352
      options.logger.log({
                    ^

TypeError: Cannot read property 'log' of undefined
    at makeRequest (/Users/adrienbecchis/git/kinesis/index.js:352:21)
    at retry (/Users/adrienbecchis/git/kinesis/index.js:468:12)
    at defaultRetryPolicy (/Users/adrienbecchis/git/kinesis/index.js:487:10)
    at /Users/adrienbecchis/git/kinesis/index.js:442:12
    at /Users/adrienbecchis/git/kinesis/index.js:301:67
    at /Users/adrienbecchis/git/kinesis/node_modules/awscred/index.js:60:16
```